### PR TITLE
MCA-6-add-controller-it

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Example of a CovidDto JSON object:
 
 ## ToDo
 Client
-* Add a API call to another service using the RestClient (Spring 6.1).
+* Add an API call to another service using the RestClient (Spring 6.1).
 
 ```java
 
@@ -86,10 +86,12 @@ Client
         .body(CovidDto.class);
 
 ```
+* Check https://www.youtube.com/watch?v=jhhi03AIin4 for adding tests to rest clients.
+
 
 Tests
-* Add UT & IT.
-* Set up / configure Jacoco for code coverage (100%).
+* Set up / configure Jacoco.
+* Add UT & IT for code coverage (100%).
 * Document the API (swagger or open API).
 
 DevOps

--- a/README.md
+++ b/README.md
@@ -64,12 +64,32 @@ Example of a CovidDto JSON object:
 ```
 
 ## ToDo
-Tests
-* Create meta annotation for IT.
-* Add test containers support for DB IT.
-* Create IT for Repo, Service and Controller Layers.
-* Set up / configure Jacoco for code coverage (100%).
+Client
+* Add a API call to another service using the RestClient (Spring 6.1).
 
+```java
+
+    private static RestClient restClient;
+
+    @BeforeAll
+    static void setUp() {
+        restClient = RestClient.builder()
+                .baseUrl("http://localhost:8080")
+                .build();
+    }
+
+
+    CovidDto result = restClient.get()
+        .uri("/api/covid/{id}", id)
+        .accept(MediaType.APPLICATION_JSON)
+        .retrieve()
+        .body(CovidDto.class);
+
+```
+
+Tests
+* Add UT & IT.
+* Set up / configure Jacoco for code coverage (100%).
 * Document the API (swagger or open API).
 
 DevOps

--- a/src/main/resources/db/data/V1_1__initial_test_data.sql
+++ b/src/main/resources/db/data/V1_1__initial_test_data.sql
@@ -1,7 +1,16 @@
+-- Continents: Africa, Europe, Asia, America, Oceania, Antarctica.
+
 -- Initial test data
 INSERT INTO public.covid
 (country, continent, confirmed, death, recovered, active, created_at)
 VALUES
-('Argentina', 'America', 1600710, 30847, 8553, 75356, CURRENT_TIMESTAMP)
-
--- Africa, Europe, Asia, America, Oceania, Antarctica
+('Argentina', 'America', 1600710, 30847, 8553, 75356, CURRENT_TIMESTAMP),
+('Congo', 'Africa', 5600710, 430847, 58553, 3575356, CURRENT_TIMESTAMP),
+('China', 'Asia', 10600710, 1030847, 568553, 7475356, CURRENT_TIMESTAMP),
+('India', 'Asia', 6600710, 130847, 58553, 4375356, CURRENT_TIMESTAMP),
+('Russia', 'Europe', 3600710, 730847, 1183553, 1475356, CURRENT_TIMESTAMP),
+('Nigeria', 'Africa', 9600710, 2430847, 4338553, 2437536, CURRENT_TIMESTAMP),
+('Iran', 'Asia', 2800710, 630847, 238553, 2135356, CURRENT_TIMESTAMP),
+('USA', 'America', 15600710, 3563087, 2385533, 9997536, CURRENT_TIMESTAMP),
+('Italy', 'Europe', 2500710, 1230847, 543853, 1875356, CURRENT_TIMESTAMP),
+('France', 'Europe', 2100370, 703084, 438553, 1075356, CURRENT_TIMESTAMP)

--- a/src/test/java/com/covid/api/configuration/BaseSpringBootIntegrationTest.java
+++ b/src/test/java/com/covid/api/configuration/BaseSpringBootIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.covid.api.configuration;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+/**
+ *  Base class for Integration Tests.
+ */
+@SpringBootIntegrationTest
+public abstract class BaseSpringBootIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17.0");
+}

--- a/src/test/java/com/covid/api/configuration/SpringBootIntegrationTest.java
+++ b/src/test/java/com/covid/api/configuration/SpringBootIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.covid.api.configuration;
 
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,6 +11,8 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public @interface SpringBootIntegrationTest {
 }

--- a/src/test/java/com/covid/api/controller/CovidControllerIT.java
+++ b/src/test/java/com/covid/api/controller/CovidControllerIT.java
@@ -1,0 +1,48 @@
+package com.covid.api.controller;
+
+import com.covid.api.configuration.BaseSpringBootIntegrationTest;
+import com.covid.api.model.CovidDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+//TODO: Implement missing tests
+class CovidControllerIT extends BaseSpringBootIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void shouldGetCovidById() {
+        //given
+        int id = 1;
+
+        //when //TODO: Change to response entity, and check the status code as well
+        CovidDto result = restTemplate.getForObject(
+                "/api/covid/byId/" + id,
+                CovidDto.class
+        );
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.country()).isEqualTo("Argentina");
+
+    }
+
+    @Test
+    void createCovidEntry() {
+    }
+
+    @Test
+    void getTop5SortedBy() {
+    }
+
+    @Test
+    void getTotalBy() {
+    }
+
+    @Test
+    void getReport() {
+    }
+}

--- a/src/test/java/com/covid/api/controller/CovidControllerIT.java
+++ b/src/test/java/com/covid/api/controller/CovidControllerIT.java
@@ -2,47 +2,154 @@ package com.covid.api.controller;
 
 import com.covid.api.configuration.BaseSpringBootIntegrationTest;
 import com.covid.api.model.CovidDto;
+import com.covid.api.model.Report;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-//TODO: Implement missing tests
+@Transactional //Used to rollback insertions, deletions and updates with the @Rollback annotation.
 class CovidControllerIT extends BaseSpringBootIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
 
     @Test
-    void shouldGetCovidById() {
+    @Rollback
+    void createCovidEntry() {
         //given
-        int id = 1;
+        CovidDto covidDto = buildCovidDto();
 
-        //when //TODO: Change to response entity, and check the status code as well
-        CovidDto result = restTemplate.getForObject(
-                "/api/covid/byId/" + id,
+        //when
+        ResponseEntity<CovidDto> response = restTemplate.exchange(
+                "/api/covid",
+                HttpMethod.POST,
+                new HttpEntity<>(covidDto),
                 CovidDto.class
         );
 
         //then
-        assertThat(result).isNotNull();
-        assertThat(result.country()).isEqualTo("Argentina");
-
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().country()).isEqualTo("Finland");
+        assertThat(response.getBody().continent()).isEqualTo("Europe");
+        assertThat(response.getBody().confirmed()).isEqualTo(1000);
+        assertThat(response.getBody().death()).isEqualTo(30);
+        assertThat(response.getBody().recovered()).isEqualTo(820);
+        assertThat(response.getBody().active()).isEqualTo(150);
     }
 
     @Test
-    void createCovidEntry() {
+    void shouldGetCovidById() {
+        //given
+        int id = 1;
+
+        //when
+        ResponseEntity<CovidDto> response = restTemplate.exchange(
+                "/api/covid/byId/" + id,
+                HttpMethod.GET,
+                null,
+                CovidDto.class
+        );
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().country()).isEqualTo("Argentina");
+        assertThat(response.getBody().continent()).isEqualTo("America");
+        assertThat(response.getBody().confirmed()).isEqualTo(1600710);
+        assertThat(response.getBody().death()).isEqualTo(30847);
+        assertThat(response.getBody().recovered()).isEqualTo(8553);
+        assertThat(response.getBody().active()).isEqualTo(75356);
     }
 
     @Test
-    void getTop5SortedBy() {
+    void shouldReturnStatus404WhenCovidIdNotFound() {
+        //given
+        int id = 11;
+
+        ResponseEntity<CovidDto> response = restTemplate.exchange(
+                "/api/covid/byId/" + id,
+                HttpMethod.GET,
+                null,
+                CovidDto.class
+        );
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
-    void getTotalBy() {
+    void getTop5CountriesByDeath() {
+        //when
+        ResponseEntity<List<CovidDto>> response = restTemplate.exchange(
+                "/api/covid/top5?by=death",
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        //TODO: Assert that contains exactly these countries: USA, Nigeria, Italy, China, Russia.
+        // Add the number of deaths as well.
+    }
+
+    @Test
+    void getTotalActiveCases() {
+        //given
+        ResponseEntity<Integer> response = restTemplate.exchange(
+                "/api/covid/total?by=active",
+                HttpMethod.GET,
+                null,
+                Integer.class
+        );
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isEqualTo(34497920);
     }
 
     @Test
     void getReport() {
+        //when
+        ResponseEntity<List<Report>> response = restTemplate.exchange(
+                "/api/covid/report",
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        //TODO: Assert that contains exactly these continents and values:
+        // Report(continent=Asia, impactFactor=0.108)
+        // Report(continent=Europe, impactFactor=0.288)
+        // Report(continent=Africa, impactFactor=0.216)
+        // Report(continent=America, impactFactor=0.224)
+    }
+
+    private CovidDto buildCovidDto() {
+        return CovidDto.builder()
+                .country("Finland")
+                .continent("Europe")
+                .confirmed(1000)
+                .death(30)
+                .recovered(820)
+                .active(150)
+                .build();
     }
 }


### PR DESCRIPTION
* Add CovidControllerIT base setup and test.
* Implement missing tests.
* Change responses to entity and validate the status code.
